### PR TITLE
Fix sentence ranking bug in key phrase extraction

### DIFF
--- a/clara10.py
+++ b/clara10.py
@@ -409,7 +409,8 @@ class TextPreprocessor:
         try:
             X = vectorizer.fit_transform(sentences)
             scores = X.sum(axis=1)
-            ranked = sorted(((scores[i], i) for i in range(len(sentences)), reverse=True)
+            # Ordena as sentenças com base nos scores de forma decrescente
+            ranked = sorted(((scores[i], i) for i in range(len(sentences))), reverse=True)
             return [sentences[i] for (score, i) in ranked[:n]]
         except:
             return sentences[:n]


### PR DESCRIPTION
## Summary
- fix missing parenthesis when ranking sentences in `extract_key_phrases`
- clarify ranking step with inline comment

## Testing
- `python -m py_compile clara10.py`

------
https://chatgpt.com/codex/tasks/task_e_689a4d2202048325889563f7e749625b